### PR TITLE
Fixes infinite loop on bad pin number

### DIFF
--- a/src/System.Device.Gpio/sys_dev_gpio_native_System_Device_Gpio_GpioController.cpp
+++ b/src/System.Device.Gpio/sys_dev_gpio_native_System_Device_Gpio_GpioController.cpp
@@ -183,7 +183,11 @@ void Library_sys_dev_gpio_native_System_Device_Gpio_GpioController::GetGpioPin(
     do
     {
         // try to get item from the array list
-        gpioPins->GetItem(index++, gpioPinBundle);
+        if (!SUCCEEDED(gpioPins->GetItem(index++, gpioPinBundle)))
+        {
+            // GetItem failed, clear to indicate failure.
+            gpioPinBundle = NULL;
+        }
 
         if (gpioPinBundle == NULL)
         {


### PR DESCRIPTION
If gpioPins->GetItem succeeds on the first call but fails later, 
the gpioPinBundle will not be null and the loop never exits.
This fix adds an error check and sets gpioBinBundle to
NULL if detected.
The if (gpioPinBundle == NULL) remains to catch
any null blocks on the list returned by GetItem.

Signed-off-by: Doug Boling <dbolinggh@bolingconsulting.com>
